### PR TITLE
Adding initial support for stop-only operators

### DIFF
--- a/pstop_c/examples/machine/machine_app.c
+++ b/pstop_c/examples/machine/machine_app.c
@@ -19,9 +19,15 @@ pstop_machine_t machine;
 
 udp_transport_data_t udp_transport;
 
-int is_operator_allowed(const device_id_t *device_id)
+operator_details_t
+is_operator_allowed(const device_id_t *device_id)
 {
-    return 1;
+    operator_details_t details;
+    details.allowed = 1;
+    details.stop_only = 0;
+    details.heartbeat_ms = 500U;
+
+    return details;
 }
 
 pstop_status_message_t lastStatus = 0;
@@ -59,7 +65,7 @@ main(int argc, char *argv[])
     pstop_application_init(&pstop_app);
 
     pstop_app.app_config.default_timeout_ms = 1000U;
-    pstop_app.operator_allowed_cb = is_operator_allowed;
+    pstop_app.operator_details_cb = is_operator_allowed;
     pstop_app.status_cb = robot_status;
 
     machine_init(&machine, &pstop_app, pstop_clients, MAX_CLIENTS);

--- a/pstop_c/pstop/include/pstop/pstop_application.h
+++ b/pstop_c/pstop/include/pstop/pstop_application.h
@@ -15,7 +15,20 @@ typedef enum {
     PSTOP_STATUS_STOP = 1
 } pstop_status_message_t;
 
-typedef int      (* is_operator_allowed_t)(const device_id_t *device_id);
+typedef struct {
+
+    int allowed;
+
+    uint64_t heartbeat_ms;
+
+    int stop_only;
+
+} operator_details_t;
+
+void operator_detail_init(operator_details_t *oper);
+
+typedef operator_details_t (* get_operator_details_t)(const device_id_t *device_id);
+
 typedef int      (* pstop_status_t)(pstop_status_message_t status);
 
 typedef void     (* log_message_t)(pstop_error_t error, const char *message);
@@ -42,12 +55,11 @@ typedef struct pstop_application_t {
     device_id_t machine_device_id;
 
     /**
-     * Simple access control to determine if an operator
-     * is allowed to connect to this machine.
-     *
-     * @Return 1 if operator is allowed, 0 otherwise
+     * Callback to return details for a specified operator.
+     * Details determine if the operator is allowed and
+     * certain features of the operator.
      */
-    is_operator_allowed_t operator_allowed_cb;
+    get_operator_details_t operator_details_cb;
 
     /**
      * Notifies the underlying hardware about the status of this PSTOP.

--- a/pstop_c/pstop/include/pstop/pstop_client_data.h
+++ b/pstop_c/pstop/include/pstop/pstop_client_data.h
@@ -27,6 +27,9 @@ typedef struct {
 
     protocol_data_t client_data;
 
+    // is this client a stop-only operator?
+    int is_stop_only;
+
     // approx how far off is the client's clock from this clock
     // compare the incoming pstop_msg.stamp to this clock.
     // Ignoring network transit time

--- a/pstop_c/pstop/src/pstop/machine.c
+++ b/pstop_c/pstop/src/pstop/machine.c
@@ -15,8 +15,15 @@ static
 pstop_error_t
 add_new_client(pstop_machine_t *machine, const device_id_t *id, pstop_client_data_t **client)
 {
+    operator_details_t details;
+    operator_detail_init(&details);
+
     // no client found, can we add it?
-    if(!machine->application->operator_allowed_cb(id)) {
+    if(machine->application->operator_details_cb != NULL) {
+        details = machine->application->operator_details_cb(id);
+    }
+
+    if(!details.allowed) {
         // This ID is not allowed
         *client = NULL;
         return PSTOP_OPERATOR_NOT_ALLOWED;
@@ -28,6 +35,9 @@ add_new_client(pstop_machine_t *machine, const device_id_t *id, pstop_client_dat
     if(*client == NULL) {
         return PSTOP_OUT_OF_OPERATOR_SPACE;
     }
+
+    (*client)->is_stop_only = details.stop_only;
+    (*client)->client_data.heartbeat_ms = details.heartbeat_ms;
 
     return PSTOP_OK;
 }
@@ -123,10 +133,12 @@ handle_need_stop(pstop_machine_t *machine, pstop_client_data_t *client, pstop_ms
     }
     else {
         if(machine->robot_state.client_stop_id == 0U) {
-            // we have a new client that sent us a STOP message.
-            machine->robot_state.robot_state = ROBOT_STATE_STOPPED;
-            machine->robot_state.client_stop_id = client->local_client_id;
-            machine->robot_state.restart_state = ROBOT_RESTART_STATE_STOP_RECEIVED;
+            if(client->is_stop_only == 0) {
+                // we have a new client that sent us a STOP message.
+                machine->robot_state.robot_state = ROBOT_STATE_STOPPED;
+                machine->robot_state.client_stop_id = client->local_client_id;
+                machine->robot_state.restart_state = ROBOT_RESTART_STATE_STOP_RECEIVED;
+            }
         }
     }
 }
@@ -148,9 +160,11 @@ handle_stop_msg(pstop_machine_t *machine, pstop_client_data_t *client, const pst
     }
 
     if(machine->robot_state.client_stop_id == 0U) {
-        machine->robot_state.robot_state = ROBOT_STATE_STOPPED;
-        machine->robot_state.client_stop_id = client->local_client_id;
-        machine->robot_state.restart_state = ROBOT_RESTART_STATE_STOP_RECEIVED;
+        if(client->is_stop_only == 0) {
+            machine->robot_state.robot_state = ROBOT_STATE_STOPPED;
+            machine->robot_state.client_stop_id = client->local_client_id;
+            machine->robot_state.restart_state = ROBOT_RESTART_STATE_STOP_RECEIVED;
+        }
     }
 
     machine->application->status_cb(PSTOP_STATUS_STOP);

--- a/pstop_c/pstop/src/pstop/protocol.c
+++ b/pstop_c/pstop/src/pstop/protocol.c
@@ -27,7 +27,15 @@ protocol_handle_message(pstop_machine_t *machine, const pstop_msg_t *req, pstop_
         return PSTOP_ERROR_INVALID_ID;
     }
 
-    if(!machine->application->operator_allowed_cb(&(req->id))) {
+    operator_details_t details;
+    operator_detail_init(&details);
+
+    // no client found, can we add it?
+    if(machine->application->operator_details_cb != NULL) {
+        details = machine->application->operator_details_cb((&req->id));
+    }
+
+    if(!details.allowed) {
         return PSTOP_OPERATOR_NOT_ALLOWED;
     }
 
@@ -67,6 +75,7 @@ protocol_handle_message(pstop_machine_t *machine, const pstop_msg_t *req, pstop_
     resp->stamp = now;
     resp->received_counter = req->counter;
     resp->received_stamp = req->stamp;
+    resp->heartbeat_timeout = client->client_data.heartbeat_ms;
     device_id_copy(&(resp->id), &(machine->application->machine_device_id));
     device_id_copy(&(resp->receiver_id), &(req->id));
 

--- a/pstop_c/pstop/src/pstop/pstop_application.c
+++ b/pstop_c/pstop/src/pstop/pstop_application.c
@@ -14,6 +14,14 @@ no_log(pstop_error_t /* error */, const char * /* message */)
 }
 
 void
+operator_detail_init(operator_details_t *oper)
+{
+    oper->allowed = 1;
+    oper->heartbeat_ms = 1000U;
+    oper->stop_only = 1;
+}
+
+void
 pstop_application_config_init(pstop_application_config_t *config)
 {
     config->default_timeout_ms = 100U;
@@ -25,7 +33,7 @@ void
 pstop_application_init(pstop_application_t *app)
 {
     pstop_os_env_init(&app->env);
-    app->operator_allowed_cb = NULL;
+    app->operator_details_cb = NULL;
     app->status_cb = NULL;
     app->log_message_cb = no_log;
     pstop_application_config_init(&app->app_config);

--- a/pstop_c/pstop/src/pstop/pstop_client_data.c
+++ b/pstop_c/pstop/src/pstop/pstop_client_data.c
@@ -18,6 +18,7 @@ pstop_client_init(pstop_client_data_t *client)
     client->missed_heartbeats_counter = 0U;
     client->client_state = PSTOP_CLIENT_UNKNOWN;
     client->local_client_id = next_client_id++;
+    client->is_stop_only = 1;
 }
 
 void

--- a/pstop_c/pstop/test/src/pstop/machine_test.c
+++ b/pstop_c/pstop/test/src/pstop/machine_test.c
@@ -17,13 +17,13 @@ get_time(void)
     return current_time++;
 }
 
-static int operator_allowed_flag;
+static operator_details_t details;
 
 static
-int
+operator_details_t
 is_operator_allowed(const device_id_t *id)
 {
-    return operator_allowed_flag;
+    return details;
 }
 
 static pstop_status_message_t lastStatus = PSTOP_STATUS_OK;
@@ -51,7 +51,7 @@ static
 pstop_application_t pstop_app = {
     .env.get_time_cb = get_time,
     .machine_device_id.data = 1236,
-    .operator_allowed_cb = is_operator_allowed,
+    .operator_details_cb = is_operator_allowed,
     .status_cb = robot_status,
     .log_message_cb = log_error,
     .app_config.default_timeout_ms = 60U,
@@ -88,7 +88,9 @@ test_new_client_operator_not_allowed(void)
     msg.heartbeat_timeout = 50U;
     msg.message = PSTOP_MESSAGE_BOND;
 
-    operator_allowed_flag = 0;
+    details.allowed = 0;
+    details.stop_only = 0;
+    details.heartbeat_ms = 500U;
     TEST_ASSERT_EQUAL(PSTOP_OPERATOR_NOT_ALLOWED, machine.handle_machine_message_cb(&machine, &msg, &resp));
 }
 
@@ -110,7 +112,9 @@ test_new_client_operator_allowed(void)
     pstop_msg_t resp;
     pstop_message_init(&resp);
 
-    operator_allowed_flag = 1;
+    details.allowed = 1;
+    details.stop_only = 0;
+    details.heartbeat_ms = 500U;
     current_time = 100U;
 
     TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_machine_message_cb(&machine, &msg, &resp));
@@ -133,7 +137,9 @@ client_send_ok(pstop_machine_t *machine, uint32_t device_id, uint8_t respMsg)
     pstop_msg_t resp;
     pstop_message_init(&resp);
 
-    operator_allowed_flag = 1;
+    details.allowed = 1;
+    details.stop_only = 0;
+    details.heartbeat_ms = 500U;
     current_time = 100U;
 
     TEST_ASSERT_EQUAL(PSTOP_OK, machine->handle_machine_message_cb(machine, &msg, &resp));
@@ -155,7 +161,9 @@ bond_client(pstop_machine_t *machine, uint32_t device_id)
     pstop_msg_t resp;
     pstop_message_init(&resp);
 
-    operator_allowed_flag = 1;
+    details.allowed = 1;
+    details.stop_only = 0;
+    details.heartbeat_ms = 500U;
     current_time = 100U;
 
     msg.message = PSTOP_MESSAGE_BOND;
@@ -207,7 +215,9 @@ test_bond_unbond(void)
     pstop_msg_t resp;
     pstop_message_init(&resp);
 
-    operator_allowed_flag = 1;
+    details.allowed = 1;
+    details.stop_only = 0;
+    details.heartbeat_ms = 500U;
     current_time = 100U;
 
     msg.message = PSTOP_MESSAGE_BOND;
@@ -243,7 +253,9 @@ test_bond_ok(void)
     pstop_msg_t resp;
     pstop_message_init(&resp);
 
-    operator_allowed_flag = 1;
+    details.allowed = 1;
+    details.stop_only = 0;
+    details.heartbeat_ms = 500U;
     current_time = 100U;
 
     msg.message = PSTOP_MESSAGE_BOND;
@@ -272,7 +284,9 @@ test_bond_bond(void)
     pstop_msg_t resp;
     pstop_message_init(&resp);
 
-    operator_allowed_flag = 1;
+    details.allowed = 1;
+    details.stop_only = 0;
+    details.heartbeat_ms = 500U;
     current_time = 100U;
 
     msg.message = PSTOP_MESSAGE_BOND;
@@ -304,7 +318,9 @@ test_bond_ok_stop(void)
     pstop_msg_t resp;
     pstop_message_init(&resp);
 
-    operator_allowed_flag = 1;
+    details.allowed = 1;
+    details.stop_only = 0;
+    details.heartbeat_ms = 500U;
     current_time = 100U;
 
     robot_status_counter = 0;
@@ -348,7 +364,9 @@ test_bond_stop_ok(void)
     pstop_msg_t resp;
     pstop_message_init(&resp);
 
-    operator_allowed_flag = 1;
+    details.allowed = 1;
+    details.stop_only = 0;
+    details.heartbeat_ms = 500U;
     current_time = 100U;
 
     robot_status_counter = 0;
@@ -378,6 +396,52 @@ test_bond_stop_ok(void)
 
 static
 void
+test_bond_stop_ok_stop_only_operator(void)
+{
+    pstop_machine_t machine;
+
+    machine_init(&machine, &pstop_app, pstop_clients, MAX_CLIENTS);
+
+    device_id_t id;
+    pstop_msg_t msg;
+    init_client(&id, &msg, 1234);
+
+    pstop_msg_t resp;
+    pstop_message_init(&resp);
+
+    details.allowed = 1;
+    details.stop_only = 1;
+    details.heartbeat_ms = 500U;
+    current_time = 100U;
+
+    robot_status_counter = 0;
+
+    msg.message = PSTOP_MESSAGE_BOND;
+    TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_machine_message_cb(&machine, &msg, &resp));
+    TEST_ASSERT_EQUAL(PSTOP_MESSAGE_BOND, resp.message);
+
+    TEST_ASSERT_EQUAL(0, robot_status_counter);
+
+    msg.message = PSTOP_MESSAGE_STOP;
+    TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_machine_message_cb(&machine, &msg, &resp));
+    TEST_ASSERT_EQUAL(PSTOP_MESSAGE_STOP, resp.message);
+
+    // stop-only operator can't transition to OK state
+    msg.message = PSTOP_MESSAGE_OK;
+    TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_machine_message_cb(&machine, &msg, &resp));
+    TEST_ASSERT_EQUAL(PSTOP_MESSAGE_OK, resp.message);
+
+    msg.message = PSTOP_MESSAGE_STOP;
+    TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_machine_message_cb(&machine, &msg, &resp));
+    TEST_ASSERT_EQUAL(PSTOP_MESSAGE_STOP, resp.message);
+
+    msg.message = PSTOP_MESSAGE_OK;
+    TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_machine_message_cb(&machine, &msg, &resp));
+    TEST_ASSERT_EQUAL(PSTOP_MESSAGE_STOP, resp.message);
+}
+
+static
+void
 test_2_clients(void)
 {
     pstop_machine_t machine;
@@ -393,7 +457,9 @@ test_2_clients(void)
     pstop_msg_t resp;
     pstop_message_init(&resp);
 
-    operator_allowed_flag = 1;
+    details.allowed = 1;
+    details.stop_only = 0;
+    details.heartbeat_ms = 500U;
     current_time = 100U;
 
     robot_status_counter = 0;
@@ -435,7 +501,9 @@ test_2_clients_stop_unbond(void)
     pstop_msg_t resp;
     pstop_message_init(&resp);
 
-    operator_allowed_flag = 1;
+    details.allowed = 1;
+    details.stop_only = 0;
+    details.heartbeat_ms = 500U;
     current_time = 100U;
 
     robot_status_counter = 0;
@@ -486,4 +554,5 @@ main_machine_test(void)
     RUN_TEST(test_2_clients_stop_unbond);
     RUN_TEST(test_bond_ok);
     RUN_TEST(test_bond_stop_ok);
+    RUN_TEST(test_bond_stop_ok_stop_only_operator);
 }

--- a/pstop_c/pstop/test/src/pstop/machine_test.c
+++ b/pstop_c/pstop/test/src/pstop/machine_test.c
@@ -429,7 +429,7 @@ test_bond_stop_ok_stop_only_operator(void)
     // stop-only operator can't transition to OK state
     msg.message = PSTOP_MESSAGE_OK;
     TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_machine_message_cb(&machine, &msg, &resp));
-    TEST_ASSERT_EQUAL(PSTOP_MESSAGE_OK, resp.message);
+    TEST_ASSERT_EQUAL(PSTOP_MESSAGE_STOP, resp.message);
 
     msg.message = PSTOP_MESSAGE_STOP;
     TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_machine_message_cb(&machine, &msg, &resp));

--- a/pstop_c/pstop/test/src/pstop/machine_timeout_test.c
+++ b/pstop_c/pstop/test/src/pstop/machine_timeout_test.c
@@ -20,10 +20,16 @@ get_time(void)
 static int operator_allowed_flag;
 
 static
-int
+operator_details_t
 is_operator_allowed(const device_id_t *id)
 {
-    return operator_allowed_flag;
+    operator_details_t details;
+
+    details.allowed = operator_allowed_flag;
+    details.stop_only = 1;
+    details.heartbeat_ms = 500U;
+
+    return details;
 }
 
 static pstop_status_message_t lastStatus = PSTOP_STATUS_OK;
@@ -51,7 +57,7 @@ static
 pstop_application_t pstop_app = {
     .env.get_time_cb = get_time,
     .machine_device_id.data = 1236,
-    .operator_allowed_cb = is_operator_allowed,
+    .operator_details_cb = is_operator_allowed,
     .status_cb = robot_status,
     .log_message_cb = log_error,
     .app_config.default_timeout_ms = 60U,

--- a/pstop_c/pstop/test/src/pstop/protocol_test.c
+++ b/pstop_c/pstop/test/src/pstop/protocol_test.c
@@ -19,10 +19,16 @@ get_time(void)
 static int operator_allowed_flag;
 
 static
-int
+operator_details_t
 is_operator_allowed(const device_id_t *id)
 {
-    return operator_allowed_flag;
+    operator_details_t details;
+
+    details.allowed = operator_allowed_flag;
+    details.stop_only = 1;
+    details.heartbeat_ms = 500U;
+
+    return details;
 }
 
 static pstop_status_message_t lastStatus = PSTOP_STATUS_OK;
@@ -53,7 +59,7 @@ static
 pstop_application_t pstop_app = {
     .env.get_time_cb = get_time,
     .machine_device_id.data = MACHINE_ID,
-    .operator_allowed_cb = is_operator_allowed,
+    .operator_details_cb = is_operator_allowed,
     .status_cb = robot_status,
     .log_message_cb = log_error,
     .app_config.default_timeout_ms = 60U,


### PR DESCRIPTION
- Changed the operator_allowed callback to return a struct
- Struct details operator info: allowed, heartbeat, stop-only
- Added test to validate stop-only can't transition to OK.