### PR TITLE
Testing unbond behavior with pstop in control

### DIFF
--- a/pstop_c/pstop/src/pstop/machine.c
+++ b/pstop_c/pstop/src/pstop/machine.c
@@ -93,7 +93,13 @@ handle_ok_msg(pstop_machine_t *machine, pstop_client_data_t *client, const pstop
 
     // this isn't the client that requested the STOP
     if(machine->robot_state.client_stop_id != client->local_client_id) {
-        resp->message = PSTOP_MESSAGE_STOP;
+        if(machine->robot_state.robot_state == ROBOT_STATE_OK) {
+            resp->message = PSTOP_MESSAGE_OK;
+        }
+        else {
+            resp->message = PSTOP_MESSAGE_STOP;
+        }
+
         return PSTOP_OK;
     }
 
@@ -123,6 +129,18 @@ handle_stop_msg(pstop_machine_t *machine, pstop_client_data_t *client, const pst
             machine->robot_state.robot_state = ROBOT_STATE_STOPPED;
             machine->robot_state.client_stop_id = client->local_client_id;
             machine->robot_state.restart_state = ROBOT_RESTART_STATE_STOP_RECEIVED;
+        }
+    }
+    else {
+        // another client has taken control of this machine
+        // but this new client wants to stop it.
+        machine->robot_state.robot_state = ROBOT_STATE_STOPPED;
+        if(client->is_stop_only == 0) {
+            machine->robot_state.client_stop_id = client->local_client_id;
+            machine->robot_state.restart_state = ROBOT_RESTART_STATE_STOP_RECEIVED;
+        }
+        else {
+            machine->robot_state.client_stop_id = 0U;
         }
     }
 

--- a/pstop_c/pstop/test/src/pstop/machine_test.c
+++ b/pstop_c/pstop/test/src/pstop/machine_test.c
@@ -765,6 +765,12 @@ test_2_clients_stop_unbond(void)
     TEST_ASSERT_EQUAL(ROBOT_RESTART_STATE_STOP_RECEIVED, machine.robot_state.restart_state);
     TEST_ASSERT_EQUAL(machine.robot_state.client_stop_id, pstop_clients[0].local_client_id);
 
+    // then OK. It's in control
+    msg1.message = PSTOP_MESSAGE_OK;
+    TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_machine_message_cb(&machine, &msg1, &resp));
+    TEST_ASSERT_EQUAL(machine.robot_state.client_stop_id, pstop_clients[0].local_client_id);
+    TEST_ASSERT_EQUAL(ROBOT_STATE_OK, machine.robot_state.robot_state);
+
     // then first node sends unbond
     msg1.message = PSTOP_MESSAGE_UNBOND;
     TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_machine_message_cb(&machine, &msg1, &resp));
@@ -778,10 +784,12 @@ test_2_clients_stop_unbond(void)
     msg2.message = PSTOP_MESSAGE_STOP;
     TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_machine_message_cb(&machine, &msg2, &resp));
     TEST_ASSERT_EQUAL(PSTOP_MESSAGE_STOP, resp.message);
+    TEST_ASSERT_EQUAL(machine.robot_state.client_stop_id, pstop_clients[1].local_client_id);
 
     msg2.message = PSTOP_MESSAGE_OK;
     TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_machine_message_cb(&machine, &msg2, &resp));
     TEST_ASSERT_EQUAL(PSTOP_MESSAGE_OK, resp.message);
+    TEST_ASSERT_EQUAL(ROBOT_STATE_OK, machine.robot_state.robot_state);
 }
 
 void


### PR DESCRIPTION
If a pstop has assumed control (stop/ok) sequence then an unbond will cause the robot to stop even if another pstop is bonded.