### PR TITLE
Adding tests for dropped resp messages

### DIFF
--- a/pstop_c/pstop/src/pstop/protocol.c
+++ b/pstop_c/pstop/src/pstop/protocol.c
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2026 Polymath Robotics, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdio.h>
 #include <stdlib.h>
 
 #include "pstop/protocol.h"
@@ -47,7 +46,10 @@ protocol_handle_message(pstop_machine_t *machine, const pstop_msg_t *req, pstop_
         if(req->stamp <= client->client_data.last_timestamp) {
             return PSTOP_MSG_OUT_OF_ORDER;
         }
-        if(req->received_counter != client->client_data.msg_counter) {
+        if(req->received_counter > client->client_data.msg_counter) {
+            return PSTOP_MSG_OUT_OF_ORDER;
+        }
+        if((client->client_data.msg_counter - req->received_counter) > machine->application->app_config.max_lost_messages) {
             return PSTOP_MSG_LOST;
         }
     }

--- a/pstop_c/pstop/test/src/pstop/protocol_test.c
+++ b/pstop_c/pstop/test/src/pstop/protocol_test.c
@@ -334,15 +334,64 @@ test_protocol_bond_invalid_echo_counter(void)
     pstop_message_init(&resp);
 
     // setup client with BOND message
+    current_time = 100;
+    TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_protocol_message_cb(&machine, &req, &resp));
+    TEST_ASSERT_EQUAL(1U, resp.counter);
+
+    req.message = PSTOP_MESSAGE_OK;
+    req.counter = 11;
+    req.stamp = 110;
+    req.received_counter = 1;
+    TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_protocol_message_cb(&machine, &req, &resp));
+
+    req.message = PSTOP_MESSAGE_OK;
+    req.counter = 12;
+    req.stamp = 120;
+    req.received_counter = 0;
+    TEST_ASSERT_EQUAL(PSTOP_MSG_LOST, machine.handle_protocol_message_cb(&machine, &req, &resp));
+}
+
+static
+void
+test_protocol_bond_missing_sent_messages(void)
+{
+    pstop_machine_t machine;
+    pstop_app.app_config.max_lost_messages = 1;
+    machine_init(&machine, &pstop_app, pstop_clients, MAX_CLIENTS);
+
+    operator_allowed_flag = 1;
+
+    pstop_msg_t req;
+    pstop_message_init(&req);
+    req.message = PSTOP_MESSAGE_BOND;
+    req.counter = 10;
+    req.stamp = 100;
+    req.id.data = PSTOP_ID;
+    req.receiver_id.data = MACHINE_ID;
+
+    pstop_msg_t resp;
+    pstop_message_init(&resp);
+
+    // setup client with BOND message
     current_time = 100;// move clock forward to 100. Next message of 90 will be in the past.
     TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_protocol_message_cb(&machine, &req, &resp));
     TEST_ASSERT_EQUAL(1U, resp.counter);
 
     req.message = PSTOP_MESSAGE_OK;
-    req.counter = 11; // missed message 11
+    req.counter = 11;
     req.stamp = 110;
-    req.received_counter = 50;
+    req.received_counter = 0; // we didn't the previous mssage
+    TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_protocol_message_cb(&machine, &req, &resp));
+    TEST_ASSERT_EQUAL(2U, resp.counter);
+    TEST_ASSERT_EQUAL(PSTOP_MESSAGE_STOP, resp.message);
+
+    req.message = PSTOP_MESSAGE_OK;
+    req.counter = 12;
+    req.stamp = 120;
+    req.received_counter = 0; // we didn't the previous mssage
     TEST_ASSERT_EQUAL(PSTOP_MSG_LOST, machine.handle_protocol_message_cb(&machine, &req, &resp));
+    TEST_ASSERT_EQUAL(2U, resp.counter);
+    TEST_ASSERT_EQUAL(PSTOP_MESSAGE_STOP, resp.message);
 }
 
 void
@@ -360,4 +409,5 @@ main_protocol_test(void)
     RUN_TEST(test_protocol_bond_invalid_timestamp);
     RUN_TEST(test_protocol_bond_missed_too_many_messages);
     RUN_TEST(test_protocol_bond_invalid_echo_counter);
+    RUN_TEST(test_protocol_bond_missing_sent_messages);
 }


### PR DESCRIPTION
- If a pstop doesn't receive a machine message then the received counter will not increment and this means we need to check against our max_missed_messages field