### PR TITLE
Improving support for timestamps

### DIFF
--- a/pstop_c/examples/client/client_app.c
+++ b/pstop_c/examples/client/client_app.c
@@ -76,7 +76,7 @@ send_msg(udp_transport_data_t *transport, pstop_os_env_t *env, protocol_data_t *
     device_id_copy(&req_msg.id, uuid);
     device_id_copy(&req_msg.receiver_id, &(machine->client_id));
     req_msg.counter = machine->msg_counter + 1U;
-    req_msg.received_counter = machine->last_counter;
+    req_msg.received_counter = machine->last_sent_counter;
     req_msg.received_stamp = machine->last_timestamp;
     req_msg.stamp = now;
     req_msg.checksum = 0x00U;
@@ -91,7 +91,7 @@ send_msg(udp_transport_data_t *transport, pstop_os_env_t *env, protocol_data_t *
         return 0;
     }
     fprintf(stderr, "Received msg: %d counter=%d\n", resp_msg.message, resp_msg.counter);
-    machine->last_counter = resp_msg.counter;
+    machine->last_sent_counter = resp_msg.counter;
     machine->last_timestamp = resp_msg.stamp;
 
     return 1;

--- a/pstop_c/pstop/include/pstop/protocol_data.h
+++ b/pstop_c/pstop/include/pstop/protocol_data.h
@@ -12,7 +12,7 @@ typedef struct {
 
     device_id_t client_id;
 
-    // last time we've heard from this client
+    // last time we've sent a message to the client
     uint64_t last_timestamp;
 
     // how frequently we should ping this client
@@ -21,7 +21,7 @@ typedef struct {
     // the counter indicating each message we are sending
     uint32_t msg_counter;
 
-    uint32_t last_counter;
+    uint32_t last_sent_counter;
 
 } protocol_data_t;
 

--- a/pstop_c/pstop/include/pstop/pstop_client_data.h
+++ b/pstop_c/pstop/include/pstop/pstop_client_data.h
@@ -32,11 +32,6 @@ typedef struct {
     // is this client a stop-only operator?
     int is_stop_only;
 
-    // approx how far off is the client's clock from this clock
-    // compare the incoming pstop_msg.stamp to this clock.
-    // Ignoring network transit time
-    int32_t clock_drift;
-
     // how many messages have we lost so far?
     uint16_t lost_message_counter;
 

--- a/pstop_c/pstop/src/pstop/machine.c
+++ b/pstop_c/pstop/src/pstop/machine.c
@@ -44,14 +44,7 @@ init_new_client(pstop_application_t *application, pstop_client_data_t *client, c
     device_id_copy(&(client->client_data.client_id), &(msg->id));
     client->client_data.last_timestamp = now;
     client->client_data.msg_counter = 0U;
-    client->client_data.last_counter = 0U;
-
-    if(now >= msg->stamp) {
-        client->clock_drift = (int64_t)(now - msg->stamp);
-    }
-    else {
-        client->clock_drift = -(int64_t)(msg->stamp - now);
-    }
+    client->client_data.last_sent_counter = 0U;
 }
 
 static

--- a/pstop_c/pstop/src/pstop/protocol.c
+++ b/pstop_c/pstop/src/pstop/protocol.c
@@ -13,6 +13,51 @@ is_checksum_valid(const pstop_msg_t *req)
     return req->checksum == req->calculated_checksum;
 }
 
+static
+pstop_error_t
+check_counter(const pstop_application_config_t *app_config, const pstop_client_data_t *client, const pstop_msg_t *req)
+{
+    if(req->counter <= client->client_data.last_sent_counter) {
+        return PSTOP_MSG_OUT_OF_ORDER;
+    }
+    if((req->counter - client->client_data.last_sent_counter) > app_config->max_lost_messages) {
+        return PSTOP_MSG_LOST;
+    }
+    if(req->received_counter > client->client_data.msg_counter) {
+        return PSTOP_MSG_OUT_OF_ORDER;
+    }
+    if((client->client_data.msg_counter - req->received_counter) > app_config->max_lost_messages) {
+        return PSTOP_MSG_LOST;
+    }
+
+    return PSTOP_OK;
+}
+
+static
+pstop_error_t
+check_timestamp(const pstop_application_config_t *app_config, const protocol_data_t *client, const pstop_msg_t *req)
+{
+    if(req->received_stamp == client->last_timestamp) {
+        return PSTOP_OK;
+    }
+
+    // did the other end miss a message?
+    if(req->received_stamp < client->last_timestamp) {
+        uint64_t diff = client->last_timestamp - req->received_stamp;
+
+        uint16_t missed = (uint16_t)(diff / client->heartbeat_ms);
+
+        if(missed > app_config->max_missed_heartbeats) {
+            return PSTOP_MSG_LOST;
+        }
+    }
+    else {
+        return PSTOP_MSG_OUT_OF_ORDER;
+    }
+
+    return PSTOP_OK;
+}
+
 pstop_error_t
 protocol_handle_message(pstop_machine_t *machine, const pstop_msg_t *req, pstop_msg_t *resp)
 {
@@ -37,20 +82,14 @@ protocol_handle_message(pstop_machine_t *machine, const pstop_msg_t *req, pstop_
 
     // if we've already seen this client, then validate the counter/timestamps
     if(client != NULL) {
-        if(req->counter <= client->client_data.last_counter) {
-            return PSTOP_MSG_OUT_OF_ORDER;
+        pstop_error_t err = check_counter(&(machine->application->app_config), client, req);
+        if(err != PSTOP_OK) {
+            return err;
         }
-        if((req->counter - client->client_data.last_counter) > machine->application->app_config.max_lost_messages) {
-            return PSTOP_MSG_LOST;
-        }
-        if(req->stamp <= client->client_data.last_timestamp) {
-            return PSTOP_MSG_OUT_OF_ORDER;
-        }
-        if(req->received_counter > client->client_data.msg_counter) {
-            return PSTOP_MSG_OUT_OF_ORDER;
-        }
-        if((client->client_data.msg_counter - req->received_counter) > machine->application->app_config.max_lost_messages) {
-            return PSTOP_MSG_LOST;
+
+        err = check_timestamp(&(machine->application->app_config), &(client->client_data), req);
+        if(err != PSTOP_OK) {
+            return err;
         }
     }
 
@@ -81,7 +120,7 @@ protocol_handle_message(pstop_machine_t *machine, const pstop_msg_t *req, pstop_
         resp->counter = client->client_data.msg_counter + 1U;
         resp->heartbeat_timeout = client->client_data.heartbeat_ms;
         client->client_data.msg_counter++;
-        client->client_data.last_counter = req->counter;
+        client->client_data.last_sent_counter = req->counter;
         client->client_data.last_timestamp = now;
     }
 

--- a/pstop_c/pstop/src/pstop/protocol_data.c
+++ b/pstop_c/pstop/src/pstop/protocol_data.c
@@ -11,5 +11,5 @@ protocol_data_init(protocol_data_t *client)
     client->last_timestamp = 0U;
     client->heartbeat_ms = 0U;
     client->msg_counter = 0U;
-    client->last_counter = 0U;
+    client->last_sent_counter = 0U;
 }

--- a/pstop_c/pstop/src/pstop/pstop_client_data.c
+++ b/pstop_c/pstop/src/pstop/pstop_client_data.c
@@ -13,7 +13,6 @@ void
 pstop_client_init(pstop_client_data_t *client)
 {
     protocol_data_init(&(client->client_data));
-    client->clock_drift = 0U;
     client->last_message = 0U;
     client->lost_message_counter = 0U;
     client->missed_heartbeats_counter = 0U;

--- a/pstop_c/pstop/test/src/pstop/protocol_test.c
+++ b/pstop_c/pstop/test/src/pstop/protocol_test.c
@@ -277,8 +277,77 @@ test_protocol_bond_invalid_timestamp(void)
 
     req.message = PSTOP_MESSAGE_OK;
     req.counter = 11;
+    req.received_stamp = resp.stamp + 1U;
     req.stamp = 90;
     TEST_ASSERT_EQUAL(PSTOP_MSG_OUT_OF_ORDER, machine.handle_protocol_message_cb(&machine, &req, &resp));
+}
+
+static
+void
+test_protocol_bond_correct_timestamp(void)
+{
+    pstop_machine_t machine;
+    machine_init(&machine, &pstop_app, pstop_clients, MAX_CLIENTS);
+
+    operator_allowed_flag = 1;
+
+    pstop_msg_t req;
+    pstop_message_init(&req);
+    req.message = PSTOP_MESSAGE_BOND;
+    req.counter = 10;
+    req.stamp = 100;
+    req.id.data = PSTOP_ID;
+    req.receiver_id.data = MACHINE_ID;
+
+    pstop_msg_t resp;
+    pstop_message_init(&resp);
+
+    // setup client with BOND message
+    current_time = 100;// move clock forward to 100. Next message of 90 will be in the past.
+    TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_protocol_message_cb(&machine, &req, &resp));
+    TEST_ASSERT_EQUAL(1U, resp.counter);
+
+    req.message = PSTOP_MESSAGE_OK;
+    req.counter = 11;
+    req.received_stamp = resp.stamp;
+    req.received_counter = resp.counter;
+    req.stamp = 110;
+    TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_protocol_message_cb(&machine, &req, &resp));
+}
+
+static
+void
+test_protocol_bond_missed_message_timestamps(void)
+{
+    pstop_machine_t machine;
+    machine_init(&machine, &pstop_app, pstop_clients, MAX_CLIENTS);
+
+    operator_allowed_flag = 1;
+
+    pstop_msg_t req;
+    pstop_message_init(&req);
+    req.message = PSTOP_MESSAGE_BOND;
+    req.counter = 10;
+    req.stamp = 5000;
+    req.id.data = PSTOP_ID;
+    req.receiver_id.data = MACHINE_ID;
+
+    pstop_msg_t resp;
+    pstop_message_init(&resp);
+
+    // setup client with BOND message
+    current_time = 5000;
+    TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_protocol_message_cb(&machine, &req, &resp));
+    TEST_ASSERT_EQUAL(1U, resp.counter);
+    TEST_ASSERT_EQUAL(5002, resp.stamp);
+    TEST_ASSERT_EQUAL(5000, resp.received_stamp);
+
+    req.message = PSTOP_MESSAGE_OK;
+    req.counter = 11;
+    req.received_stamp = 1000;
+    req.received_counter = resp.counter;
+    req.stamp = 5010;
+    TEST_ASSERT_EQUAL(PSTOP_MSG_LOST, machine.handle_protocol_message_cb(&machine, &req, &resp));
 }
 
 static
@@ -439,6 +508,8 @@ main_protocol_test(void)
     RUN_TEST(test_protocol_invalid_message);
     RUN_TEST(test_protocol_invalid_counter);
     RUN_TEST(test_protocol_bond_invalid_timestamp);
+    RUN_TEST(test_protocol_bond_correct_timestamp);
+    RUN_TEST(test_protocol_bond_missed_message_timestamps);
     RUN_TEST(test_protocol_bond_missed_too_many_messages);
     RUN_TEST(test_protocol_bond_invalid_echo_counter);
     RUN_TEST(test_protocol_bond_missing_sent_messages);

--- a/pstop_c/pstop/test/src/pstop/pstop_client_data_test.c
+++ b/pstop_c/pstop/test/src/pstop/pstop_client_data_test.c
@@ -16,7 +16,6 @@ assert_empty_client(pstop_client_data_t *client)
     TEST_ASSERT_EQUAL(0U, client->client_data.last_timestamp);
     TEST_ASSERT_EQUAL(0U, client->client_data.heartbeat_ms);
     TEST_ASSERT_EQUAL(0U, client->client_data.msg_counter);
-    TEST_ASSERT_EQUAL(0U, client->clock_drift);
 }
 
 static


### PR DESCRIPTION
- Removing clock_drift. No longer needed.
- Checking received_stamp attribute on pstop message
- Checking if received stamp is within max missed heartbeats count