### PR TITLE
pull bullseye from download archive instead of latest

### DIFF
--- a/.github/workflows/pstop_c_coverage.yml
+++ b/.github/workflows/pstop_c_coverage.yml
@@ -26,9 +26,14 @@ jobs:
           BULLSEYE_LICENSE_KEY: ${{ secrets.BULLSEYE_LICENSE_KEY }}
         run: |
           set -eu
+          tarball="/tmp/BullseyeCoverage-${BULLSEYE_VERSION}-Linux-x64.tar.xz"
           curl -fsSL \
-            "https://www.bullseye.com/download/BullseyeCoverage-${BULLSEYE_VERSION}-Linux-x64.tar.xz" \
-            | tar -xJf - -C /tmp
+            "https://www.bullseye.com/download-archive/${BULLSEYE_VERSION%.*}/BullseyeCoverage-${BULLSEYE_VERSION}-Linux-x64.tar.xz" \
+            -o "${tarball}"
+          # Fail loudly if we somehow fetched anything instead of an xz archive.
+          xz -t "${tarball}"
+          tar -xJf "${tarball}" -C /tmp
+          rm -f "${tarball}"
           sudo "/tmp/BullseyeCoverage-${BULLSEYE_VERSION}/install" \
             --prefix "${BULLSEYE_PREFIX}" \
             --key "${BULLSEYE_LICENSE_KEY}" \


### PR DESCRIPTION
CI was fetching bullseye from `https://www.bullseye.com/
  download/`, which only serves the current release. Whenever bullseye updated, it broke our download and curl ended up downloading and trying to extract an html file. This PR changes the link to point to an archived version, and adds a loud failure if what we pulled was not in fact a tarfile. 