### PR TITLE
Adding documentation for pstop application

### DIFF
--- a/pstop_c/examples/machine/machine_app.c
+++ b/pstop_c/examples/machine/machine_app.c
@@ -33,7 +33,7 @@ is_operator_allowed(const device_id_t *device_id)
 pstop_status_message_t lastStatus = 0;
 
 static
-int
+void
 robot_status(pstop_status_message_t status)
 {
     if(lastStatus != status) {
@@ -45,8 +45,6 @@ robot_status(pstop_status_message_t status)
         }
         lastStatus = status;
     }
-
-    return 0;
 }
 
 void

--- a/pstop_c/pstop/include/pstop/os.h
+++ b/pstop_c/pstop/include/pstop/os.h
@@ -6,6 +6,9 @@
 
 #include <stdint.h>
 
+/**
+ * A callback to return the current time in milliseconds.
+ */
 typedef uint64_t (* get_current_time_t)(void);
 
 typedef struct pstop_os_env_t {

--- a/pstop_c/pstop/include/pstop/pstop_application.h
+++ b/pstop_c/pstop/include/pstop/pstop_application.h
@@ -17,32 +17,82 @@ typedef enum {
 
 typedef struct {
 
+    /**
+     * Is this device_id allowed?
+     */
     int allowed;
 
+    /**
+     * The heartbeat time for this device_id in milliseconds.
+     */
     uint64_t heartbeat_ms;
 
+    /**
+     * Is this device_id a stop-only (can't transition to OK) operator?
+     */
     int stop_only;
 
 } operator_details_t;
 
+/**
+ * Utility function to default initialize an operator.
+ */
 void operator_detail_init(operator_details_t *oper);
 
+/**
+ * @brief A callback that will return operator details for the given device_id.
+ *
+ * An application must define this callback in the pstop_application_t struct
+ * and fill in the details for the specified device_id.
+ *
+ * @param device_id A client device_id
+ *
+ * @return an operator details struct with details for the specified device_id.
+ */
 typedef operator_details_t (* get_operator_details_t)(const device_id_t *device_id);
 
-typedef int      (* pstop_status_t)(pstop_status_message_t status);
+/**
+ * @brief A callback that is called by the pstop library to indicate the status of the machine.
+ *
+ * @param status The current status of the machine. Either PSTOP_STATUS_OK or PSTOP_STATUS_STOP.
+ */
+typedef void (* pstop_status_t)(pstop_status_message_t status);
 
-typedef void     (* log_message_t)(uint64_t timestamp, const device_id_t *client, uint8_t message, pstop_error_t error);
+/**
+ * @brief An optional callback to log received pstop messages.
+ *
+ * @param timestamp The timestamp this message was received.
+ * @param client The device_id that sent the message.
+ * @param message The pstop message (OK, STOP, BOND, UNBOND).
+ * @param error Any errors associated with this message
+ */
+typedef void (* log_message_t)(uint64_t timestamp, const device_id_t *client, uint8_t message, pstop_error_t error);
 
+/**
+ * Some configuration details
+ */
 typedef struct {
 
+    /**
+     * The maximum number of messages that can be lost before the pstop
+     * library reports a client as lost and stops the machine.
+     */
     uint16_t max_lost_messages;
 
+    /**
+     * The maximum number of heartbeat messages that can be lost before
+     * the library reports a client as lost and stops the machine.
+     */
     uint16_t max_missed_heartbeats;
 
 } pstop_application_config_t;
 
 typedef struct pstop_application_t {
 
+    /**
+     * An OS environment struct that contains a callback for getting
+     * the current time.
+     */
     pstop_os_env_t env;
 
     /**

--- a/pstop_c/pstop/src/pstop/protocol.c
+++ b/pstop_c/pstop/src/pstop/protocol.c
@@ -20,13 +20,13 @@ check_counter(const pstop_application_config_t *app_config, const pstop_client_d
     if(req->counter <= client->client_data.last_sent_counter) {
         return PSTOP_MSG_OUT_OF_ORDER;
     }
-    if((req->counter - client->client_data.last_sent_counter) > app_config->max_lost_messages) {
+    if((req->counter - client->client_data.last_sent_counter) > (app_config->max_lost_messages + 1U)) {
         return PSTOP_MSG_LOST;
     }
     if(req->received_counter > client->client_data.msg_counter) {
         return PSTOP_MSG_OUT_OF_ORDER;
     }
-    if((client->client_data.msg_counter - req->received_counter) > app_config->max_lost_messages) {
+    if((client->client_data.msg_counter - req->received_counter) >= (app_config->max_lost_messages + 1U)) {
         return PSTOP_MSG_LOST;
     }
 
@@ -47,7 +47,7 @@ check_timestamp(const pstop_application_config_t *app_config, const protocol_dat
 
         uint16_t missed = (uint16_t)(diff / client->heartbeat_ms);
 
-        if(missed > app_config->max_missed_heartbeats) {
+        if(missed >= (app_config->max_missed_heartbeats + 1U)) {
             return PSTOP_MSG_LOST;
         }
     }

--- a/pstop_c/pstop/src/pstop/pstop_application.c
+++ b/pstop_c/pstop/src/pstop/pstop_application.c
@@ -24,8 +24,8 @@ operator_detail_init(operator_details_t *oper)
 void
 pstop_application_config_init(pstop_application_config_t *config)
 {
-    config->max_lost_messages = 1U;
-    config->max_missed_heartbeats = 1U;
+    config->max_lost_messages = 0U;
+    config->max_missed_heartbeats = 0U;
 }
 
 void

--- a/pstop_c/pstop/test/src/pstop/machine_test.c
+++ b/pstop_c/pstop/test/src/pstop/machine_test.c
@@ -30,14 +30,12 @@ static pstop_status_message_t last_status = PSTOP_STATUS_OK;
 static int robot_status_counter = 0;
 
 static
-int
+void
 robot_status(pstop_status_message_t status)
 {
     last_status = status;
 
     robot_status_counter++;
-
-    return 0;
 }
 
 static

--- a/pstop_c/pstop/test/src/pstop/machine_timeout_test.c
+++ b/pstop_c/pstop/test/src/pstop/machine_timeout_test.c
@@ -36,14 +36,12 @@ static pstop_status_message_t lastStatus = PSTOP_STATUS_OK;
 static int robot_status_counter = 0;
 
 static
-int
+void
 robot_status(pstop_status_message_t status)
 {
     lastStatus = status;
 
     robot_status_counter++;
-
-    return 0;
 }
 
 static

--- a/pstop_c/pstop/test/src/pstop/protocol_test.c
+++ b/pstop_c/pstop/test/src/pstop/protocol_test.c
@@ -35,14 +35,12 @@ static pstop_status_message_t lastStatus = PSTOP_STATUS_OK;
 static int robot_status_counter = 0;
 
 static
-int
+void
 robot_status(pstop_status_message_t status)
 {
     lastStatus = status;
 
     robot_status_counter++;
-
-    return 0;
 }
 
 static
@@ -62,8 +60,8 @@ pstop_application_t pstop_app = {
     .operator_details_cb = is_operator_allowed,
     .status_cb = robot_status,
     .log_message_cb = log_error,
-    .app_config.max_lost_messages = 1U,
-    .app_config.max_missed_heartbeats = 1U
+    .app_config.max_lost_messages = 0U,
+    .app_config.max_missed_heartbeats = 0U
 };
 
 #define MAX_CLIENTS 2U
@@ -256,6 +254,8 @@ void
 test_protocol_bond_invalid_timestamp(void)
 {
     pstop_machine_t machine;
+    pstop_app.app_config.max_lost_messages = 0U;
+    pstop_app.app_config.max_missed_heartbeats = 0U;
     machine_init(&machine, &pstop_app, pstop_clients, MAX_CLIENTS);
 
     operator_allowed_flag = 1;
@@ -279,6 +279,7 @@ test_protocol_bond_invalid_timestamp(void)
     req.message = PSTOP_MESSAGE_OK;
     req.counter = 11;
     req.received_stamp = resp.stamp + 1U;
+    req.received_counter = resp.counter;
     req.stamp = 90;
     TEST_ASSERT_EQUAL(PSTOP_MSG_OUT_OF_ORDER, machine.handle_protocol_message_cb(&machine, &req, &resp));
 }
@@ -442,14 +443,14 @@ test_protocol_bond_missing_sent_messages(void)
     pstop_message_init(&resp);
 
     // setup client with BOND message
-    current_time = 100;// move clock forward to 100. Next message of 90 will be in the past.
+    current_time = 100;
     TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_protocol_message_cb(&machine, &req, &resp));
     TEST_ASSERT_EQUAL(1U, resp.counter);
 
     req.message = PSTOP_MESSAGE_OK;
     req.counter = 11;
     req.stamp = 110;
-    req.received_counter = 0; // we didn't the previous mssage
+    req.received_counter = 0; // we didn't receive the previous mssage
     TEST_ASSERT_EQUAL(PSTOP_OK, machine.handle_protocol_message_cb(&machine, &req, &resp));
     TEST_ASSERT_EQUAL(2U, resp.counter);
     TEST_ASSERT_EQUAL(PSTOP_MESSAGE_STOP, resp.message);
@@ -457,7 +458,7 @@ test_protocol_bond_missing_sent_messages(void)
     req.message = PSTOP_MESSAGE_OK;
     req.counter = 12;
     req.stamp = 120;
-    req.received_counter = 0; // we didn't the previous mssage
+    req.received_counter = 0; // we didn't receive the previous mssage
     TEST_ASSERT_EQUAL(PSTOP_MSG_LOST, machine.handle_protocol_message_cb(&machine, &req, &resp));
     TEST_ASSERT_EQUAL(2U, resp.counter);
     TEST_ASSERT_EQUAL(PSTOP_MESSAGE_STOP, resp.message);


### PR DESCRIPTION
- Also updated behavior of application config: max_lost_messages and max_missed_messages. Default is 0 missed messages.

- Changing return type of machine stop method to void